### PR TITLE
Omit comments in netrc files instead of failure with exception throwing

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -39,7 +39,7 @@ class Parser
      */
     public function parse($content)
     {
-        $tokens = array_filter(preg_split("/[\s]+/", $content));
+        $tokens = $this->getTokens($content);
 
         $i = 0;
         $result = array();
@@ -74,6 +74,30 @@ class Parser
         }
 
         return $result;
+    }
+
+    /**
+     * Fetches significative (not inside inline comments) tokens from the original content
+     *
+     * @param $content
+     *
+     * @return array of tokens
+     */
+    private function getTokens($content)
+    {
+        // fetch non-empty lines
+        $lines = preg_split('/\r\n|\r|\n/', $content, -1, PREG_SPLIT_NO_EMPTY);
+        $tokens = array();
+        foreach ($lines as $line) {
+            // throwing tokens after '#' sign
+            $commentCharPosition = strpos($line, "#");
+            $lineWithoutComments = ($commentCharPosition === false) ? $line : substr($line, 0, strpos($line, "#"));
+            // storing current line tokens
+            if ($lineWithoutComments) {
+                $tokens = array_merge($tokens, preg_split('/\s+/', $lineWithoutComments, -1, PREG_SPLIT_NO_EMPTY));
+            }
+        }
+        return $tokens;
     }
 }
  

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -42,6 +42,33 @@ EOF;
     }
 
     /**
+     * @test
+     */
+    public function emptyLinesAndWhiteSpacesParsedSuccessfully()
+    {
+        $netrc = <<<EOF
+
+
+machine          machine.one login john password         pass1
+machine
+
+
+ machine.two
+login steve
+    password pass2
+
+
+EOF;
+        $this->assertEquals(
+            $this->parser->parse($netrc),
+            array(
+                "machine.one" => array('login' => 'john', 'password' => 'pass1'),
+                "machine.two" => array('login' => 'steve', 'password' => 'pass2'),
+            )
+        );
+    }
+
+    /**
      * @expectedException Fduch\Netrc\Exception\ParseException
      * @test
      */
@@ -99,6 +126,37 @@ EOF;
 login john
 EOF;
         $this->parser->parse($netrc);
+    }
+
+    /**
+     * @test
+     */
+    public function commentsInNetrcAreIgnored()
+    {
+        $netrc = <<<EOF
+machine machine.one login john password pass1
+
+# machine machine.two
+#login machine.two
+machine machine.two login steve password pass2 #should be omited
+
+#machine machine.two login steve password pass2
+machine machine.three login mike
+     password pass3#should be omited
+# machine machine.two
+#login machine.two
+# steve machine.two
+
+
+EOF;
+        $this->assertEquals(
+            $this->parser->parse($netrc),
+            array(
+                "machine.one"   => array('login' => 'john', 'password' => 'pass1'),
+                "machine.two"   => array('login' => 'steve', 'password' => 'pass2'),
+                "machine.three" => array('login' => 'mike', 'password' => 'pass3'),
+            )
+        );
     }
 }
  


### PR DESCRIPTION
Comments in netrc files should not cause parse exceptions throwing 
