### PR TITLE
Random typo

### DIFF
--- a/src/Netrc.php
+++ b/src/Netrc.php
@@ -35,7 +35,7 @@ class Netrc
     public static function getDefaultPath() : string
     {
         $homePath = getenv('HOME');
-        if (!homePath) {
+        if (!$homePath) {
             throw new FileNotFoundException(
                 "HOME environment variable must be set for correct netrc handling"
             );


### PR DESCRIPTION
should also tag as 2.0.1 in case some composer somewhere says ~2.0